### PR TITLE
#167972588 Catch error thrown for unique userName during signup

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -21,8 +21,10 @@ export default {
    */
   signup: async (request, response) => {
     const existingUser = await Users.getExistingUser(request.body.email);
+    const existingUserName = await Users.getExistingUser(request.body.userName, 'userName');
 
     if (existingUser) throw new ApplicationError(409, 'You are already registered');
+    if (existingUserName) throw new ApplicationError(409, 'UserName already in use');
 
     const newUser = await Users.create(request.body);
 

--- a/src/models/Users.js
+++ b/src/models/Users.js
@@ -114,14 +114,15 @@ export default class Users extends Model {
    * @static
    * @memberof Users
    *
-   * @param {string} email
+   * @param {string} queryString - string to sort in the database
+   * @param {string} column - column to search
    *
    * @returns {Object | void} - details of existing user
    */
-  static async getExistingUser(email) {
+  static async getExistingUser(queryString, column = 'email') {
     const user = await Users.findOne({
       where: {
-        email
+        [column]: queryString
       }
     });
 

--- a/tests/fixtures/users.js
+++ b/tests/fixtures/users.js
@@ -10,6 +10,14 @@ const user = {
   password: 'gillberto5'
 };
 
+const sameUserName = {
+  firstName: 'gilbert',
+  lastName: 'erick',
+  userName: 'erickBlaze',
+  email: 'gillberto55@gmail.com',
+  password: 'gillberto5'
+};
+
 const user2 = {
   firstName: 'gilbert',
   lastName: 'erick',
@@ -163,5 +171,6 @@ export {
   randomUserToken,
   usersWithFollowing,
   profiledataForLowerCase,
-  invalidUserId
+  invalidUserId,
+  sameUserName
 };

--- a/tests/routes/auth.test.js
+++ b/tests/routes/auth.test.js
@@ -12,7 +12,8 @@ import {
   invalidEmail,
   shortPassword,
   user,
-  anotherUser
+  anotherUser,
+  sameUserName
 } from '../fixtures/users';
 
 chai.use(chaiHttp);
@@ -43,6 +44,18 @@ describe('Auth Routes', () => {
       response.body.data.user.should.have.property('firstName');
       response.body.data.user.should.have.property('lastName');
       response.body.data.user.should.have.property('email');
+    });
+
+    it('should throw an error if userName is already in use', async () => {
+      const response = await chai
+        .request(app)
+        .post('/api/v1/auth/signup')
+        .send(sameUserName);
+
+      response.should.have.status(409);
+      response.body.error.message.should.equal('UserName already in use');
+      response.body.status.should.eql('error');
+      response.body.should.have.property('error');
     });
 
     it('should return an error if user is already registered', async () => {


### PR DESCRIPTION


#### What does this PR do?
This pull request handles the Sequelize error thrown when a user attempts to register with an already existing userName.

#### Description of Task to be completed

- add verification to check for existing userName during signup

#### How should this be manually tested?
- git clone the branch
- cd into the root directory and run 'npm start:dev'
- using postman, attempt to register a user twice with the same userName using the route
http://localhost:3000/api/v1/auth/signup

#### Any Background Context You want to provide?
N/A
#### What are the relevant pivotal tracker stories?

[#167972588](https://pivotaltracker.com/story/show/167972588)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/42284402/63277568-77f96d80-c29d-11e9-8d15-f610c99d0c32.png)
![image](https://user-images.githubusercontent.com/42284402/63277588-82b40280-c29d-11e9-8775-0698c14ff4dd.png)

#### Questions:
N/A