### PR TITLE
#168054742 Fix inline comments normalisation and response message

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -23,6 +23,13 @@
         ],
         "parameters": [
           {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "Bearer {token}"
+          },
+          {
             "in": "path",
             "name": "articleId",
             "required": true
@@ -30,13 +37,6 @@
           {
             "name": "content",
             "description": "content of the comment.",
-            "in": "body",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "userId",
-            "description": "The id of user posting the comment.",
             "in": "body",
             "required": true,
             "type": "string"
@@ -400,6 +400,13 @@
         ],
         "parameters": [
           {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "Bearer {token}"
+          },
+          {
             "in": "path",
             "name": "articleId",
             "required": true
@@ -442,13 +449,6 @@
             "in": "path",
             "name": "articleId",
             "required": true
-          },
-          {
-            "name": "content",
-            "description": "content of the comment.",
-            "in": "body",
-            "required": true,
-            "type": "string"
           }
         ],
         "responses": {
@@ -460,11 +460,18 @@
     },
     "/articles/inline_comments/commentId": {
       "put": {
-        "description": "Edit an articles inline comment",
+        "description": "Edit an inline comment",
         "produces": [
           "application/json"
         ],
         "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "Bearer {token}"
+          },
           {
             "in": "path",
             "name": "commentId",
@@ -502,6 +509,13 @@
           "application/json"
         ],
         "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "default": "Bearer {token}"
+          },
           {
             "in": "path",
             "name": "commentId",

--- a/src/controllers/article.js
+++ b/src/controllers/article.js
@@ -456,7 +456,7 @@ export default {
 
     const commentData = comment.toJSON();
 
-    return response.status(200).json({ status: 'success', data: commentData, message: 'Inline comment updated succesfully' });
+    return response.status(200).json({ status: 'success', data: commentData, message: 'Inline comment retrieved succesfully' });
   },
 
   /**

--- a/src/helpers/cosine.js
+++ b/src/helpers/cosine.js
@@ -33,7 +33,7 @@ const wordOccurenceInString = (string, listOfWords) => listOfWords
  * @return {number} - sequelize object for inserted data
  */
 export default (stringOne, stringTwo) => {
-  const words = Array.from(new Set([...stringOne.split(' '), ...stringTwo.split(' ')]));
+  const words = Array.from(new Set([...stringOne.trim().split(' '), ...stringTwo.trim().split(' ')])).filter(word => word !== '');
   const stringOneVector = wordOccurenceInString(stringOne, words);
   const stringTwoVector = wordOccurenceInString(stringTwo, words);
 

--- a/src/routes/article.js
+++ b/src/routes/article.js
@@ -55,16 +55,16 @@ const router = express.Router();
  *     produces:
  *       - application/json
  *     parameters:
+ *       - name: Authorization
+ *         in: header
+ *         required: true
+ *         type: string
+ *         default: Bearer {token}
  *       - in: path
  *         name: articleId
  *         required: true
  *       - name: content
  *         description: content of the comment.
- *         in: body
- *         required: true
- *         type: string
- *       - name: userId
- *         description: The id of user posting the comment.
  *         in: body
  *         required: true
  *         type: string
@@ -417,6 +417,11 @@ router.delete(
  *     produces:
  *       - application/json
  *     parameters:
+ *       - name: Authorization
+ *         in: header
+ *         required: true
+ *         type: string
+ *         default: Bearer {token}
  *       - in: path
  *         name: articleId
  *         required: true
@@ -458,11 +463,6 @@ router.post(
  *       - in: path
  *         name: articleId
  *         required: true
- *       - name: content
- *         description: content of the comment.
- *         in: body
- *         required: true
- *         type: string
  *     responses:
  *       201:
  *         description: comments successfully retrieved
@@ -470,7 +470,6 @@ router.post(
 router.get(
   '/:articleId/inline_comments',
   validator(articlePathSchema),
-  asyncWrapper(verifyToken),
   asyncWrapper(getArticleInlineComment)
 );
 
@@ -479,10 +478,15 @@ router.get(
  *
  * /articles/inline_comments/commentId:
  *   put:
- *     description: Edit an articles inline comment
+ *     description: Edit an inline comment
  *     produces:
  *       - application/json
  *     parameters:
+ *       - name: Authorization
+ *         in: header
+ *         required: true
+ *         type: string
+ *         default: Bearer {token}
  *       - in: path
  *         name: commentId
  *         required: true
@@ -520,6 +524,11 @@ router.put(
  *     produces:
  *       - application/json
  *     parameters:
+ *       - name: Authorization
+ *         in: header
+ *         required: true
+ *         type: string
+ *         default: Bearer {token}
  *       - in: path
  *         name: commentId
  *         required: true
@@ -554,7 +563,6 @@ router.delete(
 router.get(
   '/inline_comments/:commentId',
   validator(inlineCommentSchema),
-  asyncWrapper(verifyToken),
   asyncWrapper(getInlineComment)
 );
 


### PR DESCRIPTION
#### What does this PR do?
This pull request fixes the bug when updating the validity of an inline comment when the referenced article content changed
#### Description of Task to be completed
    - fix the normalization of an inline comment on article update
      to ensure the validity of a comment
    - change the response message on comment retrieval
#### How should this be manually tested?
- Clone this repo
Using an HTTP client test the following endpoints
- ``` POST /api/v1/:articles/:articleId/inline_comments```
- ``` GET /api/v1/:articles/:articleId/inline_comments```
- ```GET /api/v1/articles/inline_comments/:commentId```
- ```PUT /api/v1/articles/inline_comments/:commentId```
- ```DELETE /api/v1/articles/inline_comments/:commentId```

- Sample body ```{
  "content": "nice Job!!!",
  "startIndex": 5,
  "endIndex": 20
}```

#### Any Background Context You want to provide?
N/A

#### What are the relevant pivotal tracker stories?

[#168054742](https://pivotaltracker.com/story/show/168054742)

#### Screenshots (if appropriate)
<img width="1424" alt="Screenshot 2019-08-22 at 3 09 51 PM" src="https://user-images.githubusercontent.com/34121552/63522761-e124ef00-c4f0-11e9-8dc8-e6a2480c79bc.png">
<img width="1423" alt="Screenshot 2019-08-22 at 3 11 06 PM" src="https://user-images.githubusercontent.com/34121552/63522763-e124ef00-c4f0-11e9-9b5a-c5175ab731d8.png">
<img width="1424" alt="Screenshot 2019-08-22 at 3 11 39 PM" src="https://user-images.githubusercontent.com/34121552/63522765-e124ef00-c4f0-11e9-868c-5eb485ad68e4.png">
<img width="1422" alt="Screenshot 2019-08-22 at 3 13 50 PM" src="https://user-images.githubusercontent.com/34121552/63522767-e1bd8580-c4f0-11e9-837a-6a63b6009aa3.png">
<img width="1425" alt="Screenshot 2019-08-22 at 3 15 45 PM" src="https://user-images.githubusercontent.com/34121552/63522768-e1bd8580-c4f0-11e9-9a93-e14595cc87ed.png">

#### Questions:
