### PR TITLE
#168059057 Fix the comment object to return net vote count

### DIFF
--- a/src/controllers/article.js
+++ b/src/controllers/article.js
@@ -6,7 +6,7 @@ import paginator from '../helpers/paginator';
 import { ApplicationError, NotFoundError } from '../helpers/errors';
 import notification from '../services/notification';
 import * as helpers from '../helpers';
-import { getTagName } from '../helpers/article';
+import { getTagName, getVoteCount } from '../helpers/article';
 import slugify from '../helpers/slugify';
 
 const { filter, extractArticles } = helpers;
@@ -21,7 +21,8 @@ const {
   Followers,
   Bookmarks,
   InlineComments,
-  Categories
+  Categories,
+  CommentVotes
 } = Models;
 
 export default {
@@ -224,13 +225,20 @@ export default {
     if (!existingArticleId) throw new ApplicationError(404, 'Non-existing articleId');
 
     const comments = await Comments.findAll({
-      where: { articleId }
+      where: { articleId },
+      include: [
+        {
+          model: CommentVotes
+        }
+      ],
     });
+
+    const commentsWithVoteCount = getVoteCount(comments);
 
     const message = comments.length ? `Comment${comments.length > 1 ? 's' : ''} retrieved successfully`
       : 'There is no comment for this article';
 
-    return response.status(200).json({ status: 'success', data: comments, message });
+    return response.status(200).json({ status: 'success', data: commentsWithVoteCount, message });
   },
 
   /** controller for creating articles

--- a/src/controllers/comment.js
+++ b/src/controllers/comment.js
@@ -6,7 +6,7 @@ const { Comments, CommentVotes } = Models;
 
 export default {
   /**
-   * controller for up voting and down voting articles
+   * controller for up voting and down voting comments
    *
    * @function
    *

--- a/src/helpers/article.js
+++ b/src/helpers/article.js
@@ -169,6 +169,27 @@ const extractArticles = result => result.reduce((accumulator, entry) => {
   return accumulator;
 }, []);
 
+/**
+ * converts comments array to include the net vote count
+ *
+ * @function
+ *
+ * @param {Array} comments - comment array to convert
+ *
+ * @returns {Array} - returns an array of comments with net vote count
+ */
+export const getVoteCount = comments => (comments.map((comment) => {
+  let voteCount = 0;
+  comment.CommentVotes.forEach(
+    (commentVote) => {
+      voteCount = (commentVote.dataValues.vote) ? voteCount += 1 : voteCount -= 1;
+    }
+  );
+  const { CommentVotes, ...commentData } = comment.dataValues;
+
+  return { ...commentData, voteCount };
+}));
+
 export default {
   idPresent,
   checkTags,

--- a/tests/fixtures/comments.js
+++ b/tests/fixtures/comments.js
@@ -72,7 +72,6 @@ const commentDownVotes = sampleComments.map(({ userId: usersId }, i, array) => (
   vote: false
 }));
 
-
 const inlineComments = Array(5).fill(0).map(() => ({
   id: uuid(),
   userId,


### PR DESCRIPTION
#### What does this PR do?
This pull request fixes the comment object, on the `getArticle comments` endpoint, to return the net `voteCount` on that comment

#### Description of Task to be completed
- implement the logic to get the net vote count of a comment
- add the property `voteCount` to the comment object showing the net vote count

#### How should this be manually tested?
- clone this branch
- run `npm install`
- using postman send a `GET` request to `/api/v1/:articles/:articleId/comments`

#### Any Background Context You want to provide?
N/A

#### What are the relevant pivotal tracker stories?

[#168059057](https://pivotaltracker.com/story/show/168059057)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/47043427/63643062-534c2e00-c6c1-11e9-9ba2-bb5aba07553c.png)

#### Questions:
N/A