### PR TITLE
#168359510 Allow access for all users to read articles

### DIFF
--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -21,7 +21,6 @@ export default {
       params: { id },
       body: payload
     } = request;
-
     if (isEmptyObject(payload)) {
       throw new ApplicationError(400, 'Request body cannot be empty');
     }
@@ -29,6 +28,7 @@ export default {
     if (request.user.id !== id) {
       throw new ApplicationError(403, 'Unauthorized update');
     }
+    if (request.file) payload.avatarUrl = request.file.secure_url;
 
     const [, affectedRows] = await Users.update(
       { ...payload },

--- a/src/routes/article.js
+++ b/src/routes/article.js
@@ -348,7 +348,7 @@ router.post(
  *       200:
  *         description: success
  */
-router.get('/:slug', asyncWrapper(verifyToken), asyncWrapper(getBySlug));
+router.get('/:slug', asyncWrapper(getBySlug));
 
 /**
  * @swagger

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -2,6 +2,7 @@ import express from 'express';
 import profile from '../controllers/user';
 import profileSchema from '../validations/profile';
 import middlewares from '../middlewares';
+import upload from '../services/imageUpload';
 
 const {
   getProfile,
@@ -61,6 +62,7 @@ const router = express.Router();
  */
 router.patch(
   '/profile/:id',
+  upload.single('image'),
   validator(profileUpdateSchema),
   asyncWrapper(verifyToken),
   asyncWrapper(updateProfile)

--- a/src/services/imageUpload.js
+++ b/src/services/imageUpload.js
@@ -7,15 +7,15 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 cloudinary.config({
-  cloud_name: process.env.CLOUD_NAME,
-  api_key: process.env.API_KEY,
-  api_secret: process.env.API_SECRET,
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
 });
 
 const storage = cloudinaryStorage({
   cloudinary,
   folder: '1kbIdeas',
-  allowedFormats: ['jpg', 'png'],
+  allowedFormats: ['jpg', 'png', 'jpeg'],
   transformation: [{ width: 400, height: 400, crop: 'limit' }],
 });
 const uploads = multer({ storage });

--- a/tests/routes/profile.test.js
+++ b/tests/routes/profile.test.js
@@ -1,8 +1,10 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
 import sinonchai from 'sinon-chai';
 
+import userController from '../../src/controllers/user';
 import Model from '../../src/models';
 import app from '../../src';
 import {
@@ -19,6 +21,7 @@ chai.use(chaiAsPromised);
 chai.use(chaiHttp);
 chai.use(sinonchai);
 
+const { updateProfile } = userController;
 const { Users, Categories } = Model;
 const profileUrl = '/api/v1/users/profile/';
 const signUrl = '/api/v1/auth/signup';
@@ -82,6 +85,30 @@ describe('Profile', () => {
       response.body.data.should.have.property('firstName');
       response.body.data.should.have.property('lastName');
       response.body.data.should.have.property('email');
+    });
+
+    it('should update user\'s profile image if image is provided', async () => {
+      const req = {
+        params: { id: 22 },
+        file: { secure_url: 'image.png' },
+        body: {
+          body: 'rrre'
+        },
+        user: { id: 22 }
+      };
+      const res = {
+        status() {},
+        json() {}
+      };
+      const affectedRows = [{ password: 'password' }];
+
+      sinon.stub(Users, 'update').callsFake(() => [1, affectedRows]);
+      sinon.stub(res, 'status').returnsThis();
+
+      await updateProfile(req, res);
+      Users.update.restore();
+
+      res.status.should.be.calledWith(200);
     });
 
     it('should not update user when it value is invalid', async () => {


### PR DESCRIPTION
#### What does this PR do?
This pull request removes authentication from the `Get /articles/:slug` route.

#### Description of Task to be completed

- allow all users to read articles
- add image upload functionality when updating profile

#### How should this be manually tested?
- Git clone this branch
- cd in to the root and run 'npm i' and 'npm run db:migrate' and 'npm run db:seed'.
- run 'npm run start:dev'
- attempt to access the `Get /articles/:slug` route.
- attempt to upload a picture with the field 'image to the route `Patch /users/profile/:id` route.
#### Any Background Context You want to provide?
N/A
#### What are the relevant pivotal tracker stories?

[#168359510](https://pivotaltracker.com/story/show/168359510)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/42284402/64478669-55bf8500-d1a3-11e9-834d-c9a0a8472859.png)
![image](https://user-images.githubusercontent.com/42284402/64478672-6243dd80-d1a3-11e9-9667-87a75d6de6a9.png)

#### Questions:
N/A